### PR TITLE
add clear left to contact form

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -370,6 +370,7 @@ h3.resume-subtitle {
 }
 
 .contact-form .form-input:nth-child(3) {
+  clear: left;
   width: 100%;
   padding: 0 15px;
 }


### PR DESCRIPTION
U25 Contact Form - CSS 中有學生對 contact form 沒有清掉 left 有疑問，建議在使用 float: left 後清掉比較正確，雖然這邊不影響排版。